### PR TITLE
Added a custom key function in server side

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,20 @@ An example using it within an Om component:
     )
 ```
 
+The `uploaded` channel will return a map with the `:file` object that
+was uploaded and a `:response` map that contains the `:location`,
+`:bucket`, `:key`, and `:etag` of the file in S3. 
+
 ## Changes
+
+#### Not Released
+
+- Added `:key-fn` option `s3-beam.handler/sign-upload` to generate
+  custom S3 keys from `file-name` and `mime-type`.
+
+#### 0.3.0
+
+- Added custom `/sign` route. ([1cb9b2](https://github.com/martinklepsch/s3-beam/commit/1cb9b2703691e172e275a95490b3fc8209dfa409))
 
 #### 0.2.0
 


### PR DESCRIPTION
Users can now provide a `:key-fn` to the server handler which given `file-name` and `mime-type` will determine the key to use for the S3 file.

Caveat: if the client provides a file `my-file.txt` and the `:key-fn` generates a random number as a key (i.e. `12314345`), the file location in S3 is given by `12314345`, which is what was passed back in the `s3-pipe` uploaded channel. The file location is no longer sufficient for the client to know which file was successfully uploaded (in case of parallel uploads).

My (non-backwards-compatible) proposal is to put in the `uploaded` channel all information relevant to the client: both the file object that was uploaded and the response from S3 which contains the `:key`, `:location`, `:bucket`, and `:etag`.