### PR TITLE
Use can instead of might

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ map to `s3-pipe` in the frontend.
 In your frontend code you can now use `s3-beam.client/s3-pipe`.
 `s3-pipe`'s argument is a channel where completed uploads will be
 reported. The function returns a channel where you can put File
-objects that should get uploaded. It might also take an extra options
+objects that should get uploaded. It can also take an extra options
 map with the previously mentioned `:server-url` like so:
 
     (s3/s3-pipe uploaded {:server-url "/my-cool-route"})


### PR DESCRIPTION
It's more idiomatic and natural to use "can" here instead of "might".

"You can provide an option" talks about ability, gives permission and explains possiblilty here.
"You might provide an option" talks about  that it will or won't happen in the future, but says nothing about what is possible or permissible here.

The German können, wollen, müssen, sollen and dürfen are all quite a bit different than their usual direct translations into English, sadly. English is a LOT less precise.