### PR TITLE
Make namespace in client more explicit (in readme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,15 @@ reported. The function returns a channel where you can put File
 objects that should get uploaded. It can also take an extra options
 map with the previously mentioned `:server-url` like so:
 
-    (s3/s3-pipe uploaded {:server-url "/my-cool-route"})
+    (s3/s3-pipe uploaded {:server-url "/my-cool-route"}) ; assuming s3-beam.client is NS aliased as s3
 
 An example using it within an Om component:
 
 ```clj
+(ns your.client
+  (:require [s3-beam.client :as s3]
+  ...))
+  
 (defcomponent upload-form [app-state owner]
   (init-state [_]
     (let [uploaded (chan 20)]


### PR DESCRIPTION
Just added the namespace in the client to make it more clear what s3 is aliased to.