### PR TITLE
Allow specification of ACL when creating signed url for upload

### DIFF
--- a/src/clj/s3_beam/handler.clj
+++ b/src/clj/s3_beam/handler.clj
@@ -14,19 +14,16 @@
 
 (defn policy
   "Generate policy for upload of `key` with `mime-type` to be uploaded
-  within optional `expiration-window` (defaults to 60), and optional
-  `acl` (defaults to 'public-read')."
-  ([bucket key mime-type]
-     (policy bucket key mime-type 60 "public-read"))
-  ([bucket key mime-type expiration-window acl]
-     (ring.util.codec/base64-encode
+   within `expiration-window`, and `acl`."
+  [bucket key mime-type expiration-window acl]
+  (ring.util.codec/base64-encode
       (.getBytes (json/write-str { "expiration" (now-plus expiration-window)
                                    "conditions" [{"bucket" bucket}
                                                  {"acl" acl}
                                                  ["starts-with" "$Content-Type" mime-type]
                                                  ["starts-with" "$key" key]
                                                  {"success_action_status" "201"}]})
-                 "UTF-8"))))
+                 "UTF-8")))
 
 (defn hmac-sha1 [key string]
   "Returns signature of `string` with a given `key` using SHA-1 HMAC."


### PR DESCRIPTION
I would like to use s3-beam to create signed urls with acl's that differ from public-read, such as authenticated-read. I've made the necessary small mod to allow this. Can you review and include? Thx