### PR TITLE
Handle errors, object key naming, and headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ from the browser to S3 (CORS upload).
 
 [](dependency)
 ```clojure
-[org.martinklepsch/s3-beam "0.3.1"] ;; latest release
+[org.martinklepsch/s3-beam "0.5.0"] ;; latest release
 ```
 [](/dependency)
 
@@ -55,10 +55,29 @@ map to `s3-pipe` in the frontend.
 In your frontend code you can now use `s3-beam.client/s3-pipe`.
 `s3-pipe`'s argument is a channel where completed uploads will be
 reported. The function returns a channel where you can put File
-objects that should get uploaded. It can also take an extra options
-map with the previously mentioned `:server-url` like so:
+objects of a file map that should get uploaded. It can also take an 
+extra options map with the previously mentioned `:server-url` like so:
 
     (s3/s3-pipe uploaded {:server-url "/my-cool-route"})
+
+The full options map spec is:
+
+- `:server-url` the signing server url, defaults to "/sign"
+- `:response-parser` a function to process the signing response from the signing server into EDN
+                     defaults to read-string. 
+- `:key-fn` a function used to generate the object key for the uploaded file on S3
+                   defaults to nil, which means it will use the passed filename as the object key.             
+- `:headers-fn` a function used to create the headers for the GET request to the signing server.
+                   The returned headers should be a Clojure map of header name Strings to corresponding 
+                   header value Strings.
+                   
+If you choose to place a file map instead of a `File` object, you file map should follow:
+
+- `:file`                  A `File` object
+- `:identifier` (optional) A variable used to uniquely identify this file upload.
+                           This will be included in the response channel.
+- `:key` (optional)        The file-name parameter that is sent to the signing server. If a `:key` key
+                           exists in the input-map it will be used instead of the key-fn as an object-key.
 
 An example using it within an Om component:
 
@@ -83,7 +102,74 @@ An example using it within an Om component:
     )
 ```
 
+The spec for the returned map (in the example above the returned map is `v`):
+
+- `:file` The `File` object from the uploaded file
+- `:response` The upload response from S3 as a map with:
+ - `:location` The S3 URL of the uploaded file
+ - `:bucket` The S3 bucket where the file is located
+ - `:key` The S3 key for the file
+ - `:etag` The etag for the file          
+- `:xhr` The `XhrIo` object used to POST to S3
+- `:identifier` A value used to uniquely identify the uploaded file
+
+Or, if an error occurs during upload processing, an error-map will be placed on the response channel:
+
+- `:identifier` A variable used to uniquely identify this file upload. This will be included in the response channel.
+- `:error-code` The error code from the XHR
+- `:error-message` The debug message from the error code
+- `:http-error-code` The HTTP error code
+
 ## Changes
+
+#### 0.5.0
+
+- Allow the upload-queue to be passed an input-map instead of a file. This
+  input-map follows the spec:
+  
+    - `:file`                  A `File` object
+    - `:identifier` (optional) A variable used to uniquely identify this file upload.
+                               This will be included in the response channel.
+    - `:key` (optional)        The file-name parameter that is sent to the signing server. If a `:key` key
+                               exists in the input-map it will be used instead of the key-fn as an object-key.
+- Introduce error handling. When an error has been thrown while uploading a file to S3
+  an error-map will be put onto the channel. The error-map follows the spec:
+  
+    - `:identifier`      A variable used to uniquely identify this file upload. This will be
+                         included in the response channel.
+    - `:error-code`      The error code from the XHR
+    - `:error-message`   The debug message from the error code
+    - `:http-error-code` The HTTP error code
+- New options are available in the options map:
+
+    - `:response-parser` a function to process the signing response from the signing server into EDN
+                         defaults to read-string.
+    - `:key-fn`          a function used to generate the object key for the uploaded file on S3
+                         defaults to nil, which means it will use the passed filename as the object key.
+    - `:headers-fn`      a function used to create the headers for the GET request to the signing server.
+- Places a map into the upload-channel with: 
+    - `:file`       The `File` object from the uploaded file
+    - `:response`   The upload response from S3 as a map with:
+     - `:location` The S3 URL of the uploaded file
+     - `:bucket`   The S3 bucket where the file is located
+     - `:key`      The S3 key for the file
+     - `:etag`     The etag for the file
+    - `:xhr`        The `XhrIo` object used to POST to S3
+    - `:identifier` A value used to uniquely identify the uploaded file
+    
+#### 0.4.0
+
+- Support custom ACLs. The `sign-upload` function that can be used to
+  implement custom signing routes now supports an additional `:acl` key
+  to upload assets with a different ACL than `public-read`.
+
+        (sign-upload {:file-name "xyz.html" :mime-type "text/html"}
+                     {:bucket bucket
+                      :aws-zone aws-zone
+                      :aws-access-key access-key
+                      :aws-secret-key secret-key
+                      :acl "authenticated-read"})
+- Changes the arity of `s3-beam.handler/policy` function.
 
 #### 0.3.1
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 `s3-beam` is a Clojure/Clojurescript library designed to help you upload files
 from the browser to S3 (CORS upload).
 
-```clj
-[org.martinklepsch/s3-beam "0.3.0"]
+[](dependency)
+```clojure
+[org.martinklepsch/s3-beam "0.3.1"] ;; latest release
 ```
+[](/dependency)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ map to `s3-pipe` in the frontend.
 In your frontend code you can now use `s3-beam.client/s3-pipe`.
 `s3-pipe`'s argument is a channel where completed uploads will be
 reported. The function returns a channel where you can put File
-objects that should get uploaded. It might also take an extra options
+objects that should get uploaded. It can also take an extra options
 map with the previously mentioned `:server-url` like so:
 
     (s3/s3-pipe uploaded {:server-url "/my-cool-route"})

--- a/build.boot
+++ b/build.boot
@@ -1,0 +1,21 @@
+(set-env!
+  :source-paths   #{"src/clj" "src/cljs"}
+  :dependencies  '[[adzerk/bootlaces   "0.1.11" :scope "test"]
+                   [org.clojure/clojure "1.6.0" :scope "provided"]
+                   [org.clojure/clojurescript "0.0-2371" :scope "provided"]
+                   [org.clojure/data.json "0.2.5"]
+                   [org.clojure/core.async "0.1.346.0-17112a-alpha"]])
+
+(require '[adzerk.bootlaces :refer :all])
+
+(def +version+ "0.3.1")
+(bootlaces! +version+)
+(set-env! :resource-paths #{"src/clj" "src/cljs"})
+
+(task-options!
+ pom  {:project     'org.martinklepsch/s3-beam
+       :version     +version+
+       :description "CORS Upload to S3 via Clojure(script)"
+       :url         "http://github.com/martinklepsch/s3-beam"
+       :scm         {:url "https://github.com/martinklepsch/s3-beam"}
+       :license     {"EPL" "http://www.eclipse.org/legal/epl-v10.html"}})

--- a/build.boot
+++ b/build.boot
@@ -8,7 +8,7 @@
 
 (require '[adzerk.bootlaces :refer :all])
 
-(def +version+ "0.3.1")
+(def +version+ "0.5.0")
 (bootlaces! +version+)
 (set-env! :resource-paths #{"src/clj" "src/cljs"})
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.martinklepsch/s3-beam "0.3.1"
+(defproject org.martinklepsch/s3-beam "0.5.0"
   :author "Martin Klepsch <http://www.martinklepsch.org>"
   :description "CORS Upload to S3 via Clojure(script)"
   :url "http://github.com/martinklepsch/s3-beam"

--- a/src/cljs/s3_beam/client.cljs
+++ b/src/cljs/s3_beam/client.cljs
@@ -4,11 +4,9 @@
             [cljs.core.async :as async :refer [chan put! close! pipeline-async]]
             [goog.dom :as gdom]
             [goog.events :as events])
-  (:import  (goog Uri)
-            (goog.net XhrIo)
-            goog.net.EventType
-            goog.net.ErrorCode
-            (goog.events EventType)))
+  (:import  [goog Uri]
+            [goog.net XhrIo EventType ErrorCode]
+            [goog.events EventType]))
 
 (defn file->map [f]
   {:name (.-name f)

--- a/src/cljs/s3_beam/client.cljs
+++ b/src/cljs/s3_beam/client.cljs
@@ -4,9 +4,9 @@
             [cljs.core.async :as async :refer [chan put! close! pipeline-async]]
             [goog.dom :as gdom]
             [goog.events :as events])
-  (:import  [goog Uri]
-            [goog.net XhrIo EventType ErrorCode]
-            [goog.events EventType]))
+  (:import [goog Uri]
+           [goog.net XhrIo EventType ErrorCode]
+           [goog.events EventType]))
 
 (defn file->map [f]
   {:name (.-name f)
@@ -28,33 +28,33 @@
   Alternatively, if a :key key exists in the input-map, use that in preference to the key-fn as an object-key.
   Sends the request to the server-url to be signed."
   [server-url edn-ize key-fn input-map-or-file ch]
-  (let [xhr      (XhrIo.)
+  (let [xhr (XhrIo.)
         {:keys [file identifier] :as input-map}
-                 (if (map? input-map-or-file)
-                   input-map-or-file
-                   {:file input-map-or-file})
-        fmap     (file->map file)
-        fmap     (cond
-                   (:key input-map) (assoc fmap :name (:key input-map))
-                   key-fn           (update-in fmap [:name] key-fn)
-                   :else            fmap)]
+        (if (map? input-map-or-file)
+          input-map-or-file
+          {:file input-map-or-file})
+        fmap (file->map file)
+        fmap (cond
+               (:key input-map) (assoc fmap :name (:key input-map))
+               key-fn (update-in fmap [:name] key-fn)
+               :else fmap)]
     (events/listen xhr goog.net.EventType.SUCCESS
-      (fn [_]
-        (put! ch {:f file
-                  :signature (edn-ize (.getResponseText xhr))
-                  :identifier identifier})
-        (close! ch)))
+                   (fn [_]
+                     (put! ch {:f          file
+                               :signature  (edn-ize (.getResponseText xhr))
+                               :identifier identifier})
+                     (close! ch)))
     (events/listen xhr goog.net.EventType.ERROR
-      (fn [_]
-        (let [error-code      (.getLastErrorCode xhr)
-              error-message   (.getDebugMessage goog.net.ErrorCode error-code)
-              http-error-code (.getStatus xhr)]
-          (put! ch {:identifier      identifier
-                    :error-code      error-code
-                    :error-message   (str "While trying to sign file: "
-                                           error-message)
-                    :http-error-code http-error-code})
-          (close! ch))))
+                   (fn [_]
+                     (let [error-code (.getLastErrorCode xhr)
+                           error-message (.getDebugMessage goog.net.ErrorCode error-code)
+                           http-error-code (.getStatus xhr)]
+                       (put! ch {:identifier      identifier
+                                 :error-code      error-code
+                                 :error-message   (str "While trying to sign file: "
+                                                       error-message)
+                                 :http-error-code http-error-code})
+                       (close! ch))))
     (. xhr send (signing-url server-url (:name fmap) (:type fmap)) "GET")))
 
 (defn formdata-from-map [m]
@@ -68,7 +68,7 @@
   [xml]
   (let [kv (->> (array-seq (.. xml -firstChild -childNodes))
                 (map (fn [n] [(.toLowerCase (.-nodeName n))
-                             (gdom/getTextContent n)])))]
+                              (gdom/getTextContent n)])))]
     (zipmap (map (comp keyword first) kv) (map second kv))))
 
 (defn upload-file
@@ -85,33 +85,33 @@
     (do
       (put! ch upload-info)
       (close! ch))
-    (let [xhr        (XhrIo.)
+    (let [xhr (XhrIo.)
           identifier (:identifier upload-info)
           sig-fields [:key :Content-Type :success_action_status :policy :AWSAccessKeyId :signature :acl]
-          signature  (select-keys (:signature upload-info) sig-fields)
-          form-data  (formdata-from-map (merge signature {:file (:f upload-info)}))]
+          signature (select-keys (:signature upload-info) sig-fields)
+          form-data (formdata-from-map (merge signature {:file (:f upload-info)}))]
       (events/listen xhr goog.net.EventType.SUCCESS
-        (fn [_]
-          (put! ch {:file       (:f upload-info)
-                    :response   (when-let [response-xml (.getResponseXml xhr)]
-                                    (xml->map response-xml))
-                    :xhr xhr
-                    :identifier identifier})
-          (close! ch)))
+                     (fn [_]
+                       (put! ch {:file       (:f upload-info)
+                                 :response   (when-let [response-xml (.getResponseXml xhr)]
+                                               (xml->map response-xml))
+                                 :xhr        xhr
+                                 :identifier identifier})
+                       (close! ch)))
       (events/listen xhr goog.net.EventType.ERROR
-        (fn [_]
-          (let [error-code      (.getLastErrorCode xhr)
-                error-message   (.getDebugMessage goog.net.ErrorCode error-code)
-                http-error-code (.getStatus xhr)]
-            (put! ch {:identifier      identifier
-                      :error-code      error-code
-                      :error-message   (str "While trying to upload file: "
-                                             error-message)
-                      :response   (when-let [response-xml (.getResponseXml xhr)]
-                                    (xml->map response-xml))
-                      :xhr xhr
-                      :http-error-code http-error-code})
-            (close! ch))))
+                     (fn [_]
+                       (let [error-code (.getLastErrorCode xhr)
+                             error-message (.getDebugMessage goog.net.ErrorCode error-code)
+                             http-error-code (.getStatus xhr)]
+                         (put! ch {:identifier      identifier
+                                   :error-code      error-code
+                                   :error-message   (str "While trying to upload file: "
+                                                         error-message)
+                                   :response        (when-let [response-xml (.getResponseXml xhr)]
+                                                      (xml->map response-xml))
+                                   :xhr             xhr
+                                   :http-error-code http-error-code})
+                         (close! ch))))
       (. xhr send (:action (:signature upload-info)) "POST" form-data))))
 
 (defn s3-pipe
@@ -125,10 +125,10 @@
                        defaults to nil, which means it will use the passed filename as the object key."
   ([report-chan] (s3-pipe report-chan {}))
   ([report-chan opts]
-   (let [opts       (merge {:server-url "/sign" :response-parser #(reader/read-string %)}
-                           opts)
+   (let [opts (merge {:server-url "/sign" :response-parser #(reader/read-string %)}
+                     opts)
          to-process (chan)
-         signed     (chan)]
+         signed (chan)]
      (pipeline-async 3
                      signed
                      (partial sign-file

--- a/src/cljs/s3_beam/client.cljs
+++ b/src/cljs/s3_beam/client.cljs
@@ -83,7 +83,7 @@
   [upload-info ch]
   (if (contains? upload-info :error-code)
     (do
-      (put! ch (select-keys upload-info [:identifier :error-code :error-message :http-error-code]))
+      (put! ch upload-info)
       (close! ch))
     (let [xhr        (XhrIo.)
           identifier (:identifier upload-info)

--- a/src/cljs/s3_beam/client.cljs
+++ b/src/cljs/s3_beam/client.cljs
@@ -107,9 +107,8 @@
                       :error-code      error-code
                       :error-message   (str "While trying to upload file: "
                                              error-message)
-                      :response   (if-let [response-xml (.getResponseXml xhr)]
-                                    (xml->map response-xml)
-                                    "")
+                      :response   (when-let [response-xml (.getResponseXml xhr)]
+                                    (xml->map response-xml))
                       :xhr xhr
                       :http-error-code http-error-code})
             (close! ch))))

--- a/src/cljs/s3_beam/client.cljs
+++ b/src/cljs/s3_beam/client.cljs
@@ -72,9 +72,9 @@
     (zipmap (map (comp keyword first) kv) (map second kv))))
 
 (defn upload-file
-  "Take the signature information `upload-info`, and a channel `ch`,
+  "Take the signature information `upload-info`, and a response channel `ch`,
   and does the S3 upload.
-  Returns a map with:
+  Responds on the response channel with a map with:
     :file - the File that was uploaded
     :response - a map of S3 metadata: :key, :location, :bucket, :etag
     :identifier - an identifier pass-through value for caller to identify the file with

--- a/src/cljs/s3_beam/client.cljs
+++ b/src/cljs/s3_beam/client.cljs
@@ -1,10 +1,14 @@
 (ns s3-beam.client
-  (:import (goog Uri))
   (:require-macros [cljs.core.async.macros :refer [go]])
   (:require [cljs.reader :as reader]
             [cljs.core.async :as async :refer [chan put! close! pipeline-async]]
             [goog.dom :as gdom]
-            [goog.net.XhrIo :as xhr]))
+            [goog.events :as events])
+  (:import  (goog Uri)
+            (goog.net XhrIo)
+            goog.net.EventType
+            goog.net.ErrorCode
+            (goog.events EventType)))
 
 (defn file->map [f]
   {:name (.-name f)
@@ -17,13 +21,43 @@
                (.setParameterValue "file-name" fname)
                (.setParameterValue "mime-type" fmime))))
 
-(defn sign-file [server-url file ch]
-  (let [fmap    (file->map file)
-        edn-ize #(reader/read-string (.getResponseText (.-target %)))]
-    (xhr/send (signing-url server-url (:name fmap) (:type fmap))
-           (fn [res]
-             (put! ch {:f file :signature (edn-ize res)})
-             (close! ch)))))
+(defn sign-file
+  "Takes a `server-url`, either an input map (with keys :file and optionally :identifier and :key),
+  as `input-map-or-file` and a channel `ch`. Also takes a fn `edn-ize` which is for interpreting
+  the server response text into edn.
+  Takes a `key-fn` function that takes one argument (the filename) and generates a object-key to
+  use to create the file on S3.
+  Alternatively, if a :key key exists in the input-map, use that in preference to the key-fn as an object-key.
+  Sends the request to the server-url to be signed."
+  [server-url edn-ize key-fn input-map-or-file ch]
+  (let [xhr      (XhrIo.)
+        {:keys [file identifier] :as input-map}
+                 (if (map? input-map-or-file)
+                   input-map-or-file
+                   {:file input-map-or-file})
+        fmap     (file->map file)
+        fmap     (cond
+                   (:key input-map) (assoc fmap :name (:key input-map))
+                   key-fn           (update-in fmap [:name] key-fn)
+                   :else            fmap)]
+    (events/listen xhr goog.net.EventType.SUCCESS
+      (fn [_]
+        (put! ch {:f file
+                  :signature (edn-ize (.getResponseText xhr))
+                  :identifier identifier})
+        (close! ch)))
+    (events/listen xhr goog.net.EventType.ERROR
+      (fn [_]
+        (let [error-code      (.getLastErrorCode xhr)
+              error-message   (.getDebugMessage goog.net.ErrorCode error-code)
+              http-error-code (.getStatus xhr)]
+          (put! ch {:identifier      identifier
+                    :error-code      error-code
+                    :error-message   (str "While trying to sign file: "
+                                           error-message)
+                    :http-error-code http-error-code})
+          (close! ch))))
+    (. xhr (send (signing-url server-url (:name fmap) (:type fmap)) "GET" nil nil))))
 
 (defn formdata-from-map [m]
   (let [fd (new js/FormData)]
@@ -31,28 +65,80 @@
       (.append fd (name k) v))
     fd))
 
-(defn upload-file [upload-info ch]
-  (let [sig-fields [:key :Content-Type :success_action_status :policy :AWSAccessKeyId :signature :acl]
-        signature  (select-keys (:signature upload-info) sig-fields)
-        form-data  (formdata-from-map (merge signature {:file (:f upload-info)}))]
-    (xhr/send
-     (:action (:signature upload-info))
-     (fn [res]
-       (let [loc (aget (.getElementsByTagName (.getResponseXml (.-target res)) "Location") 0)]
-         (put! ch (gdom/getTextContent loc))
-         (close! ch)))
-     "POST"
-     form-data)))
+(defn xml->map
+  "Transforms a shallow XML document into a map."
+  [xml]
+  (let [kv (->> (array-seq (.. xml -firstChild -childNodes))
+                (map (fn [n] [(.toLowerCase (.-nodeName n))
+                             (gdom/getTextContent n)])))]
+    (zipmap (map (comp keyword first) kv) (map second kv))))
+
+(defn upload-file
+  "Take the signature information `upload-info`, and a channel `ch`,
+  and does the S3 upload.
+  Returns a map with:
+    :file - the File that was uploaded
+    :response - a map of S3 metadata: :key, :location, :bucket, :etag
+    :identifier - an identifier pass-through value for caller to identify the file with
+  If the upload-info has an :error-code key because the signing failed, skips the xhr/send of the file,
+  and simply replies with the error messages and codes from the failed upload-info sign attempt."
+  [upload-info ch]
+  (if (contains? upload-info :error-code)
+    (do
+      (put! ch (select-keys upload-info [:identifier :error-code :error-message :http-error-code]))
+      (close! ch))
+    (let [xhr        (XhrIo.)
+          identifier (:identifier upload-info)
+          sig-fields [:key :Content-Type :success_action_status :policy :AWSAccessKeyId :signature :acl]
+          signature  (select-keys (:signature upload-info) sig-fields)
+          form-data  (formdata-from-map (merge signature {:file (:f upload-info)}))]
+      (events/listen xhr goog.net.EventType.SUCCESS
+        (fn [_]
+          (put! ch {:file       (:f upload-info)
+                    :response   (if-let [response-xml (.getResponseXml xhr)]
+                                    (xml->map response-xml)
+                                    "")
+                    :xhr xhr
+                    :identifier identifier})
+          (close! ch)))
+      (events/listen xhr goog.net.EventType.ERROR
+        (fn [_]
+          (let [error-code      (.getLastErrorCode xhr)
+                error-message   (.getDebugMessage goog.net.ErrorCode error-code)
+                http-error-code (.getStatus xhr)]
+            (put! ch {:identifier      identifier
+                      :error-code      error-code
+                      :error-message   (str "While trying to upload file: "
+                                             error-message)
+                      :response   (if-let [response-xml (.getResponseXml xhr)]
+                                    (xml->map response-xml)
+                                    "")
+                      :xhr xhr
+                      :http-error-code http-error-code})
+            (close! ch))))
+      (. xhr (send (:action (:signature upload-info)) "POST" form-data nil)))))
 
 (defn s3-pipe
-  "Takes a channel where completed uploads will be reported and 
-  returns a channel where you can put File objects that should get uploaded.
+  "Takes a channel where completed uploads will be reported as a map and returns a channel where
+  you can put File objects, or input maps that should get uploaded. (see `upload-file` and `sign-file`)
   May also take an options map with:
-    :server-url - the sign server url, defaults to \"/sign\""
-  ([report-chan] (s3-pipe report-chan {:server-url "/sign"}))
+    :server-url - the signing server url, defaults to \"/sign\"
+    :response-parser - a function to process the signing response from the signing server into EDN
+    - defaults to read-string.
+    :key-fn - a function used to generate the object key for the uploaded file on S3
+    - defaults to nil, which means it will use the passed filename as the object key."
+  ([report-chan] (s3-pipe report-chan {}))
   ([report-chan opts]
-   (let [to-process (chan)
+   (let [opts       (merge {:server-url "/sign" :response-parser #(reader/read-string %)}
+                           opts)
+         to-process (chan)
          signed     (chan)]
-     (pipeline-async 3 signed (partial sign-file (:server-url opts)) to-process)
+     (pipeline-async 3
+                     signed
+                     (partial sign-file
+                              (:server-url opts)
+                              (:response-parser opts)
+                              (:key-fn opts))
+                     to-process)
      (pipeline-async 3 report-chan upload-file signed)
      to-process)))

--- a/src/cljs/s3_beam/client.cljs
+++ b/src/cljs/s3_beam/client.cljs
@@ -27,8 +27,8 @@
       :file                  - A `File` object
       :identifier (optional) - A variable used to uniquely identify this file upload.
                                This will be included in the response channel.
-      :key (optional)        - The file-name parameter that is sent to the signing server.
-   Alternatively, if a :key key exists in the input-map, use that in preference to the key-fn as an object-key.
+      :key (optional)        - The file-name parameter that is sent to the signing server. If a :key key
+                               exists in the input-map it will be used instead of the key-fn as an object-key.
    Sends the request to the server-url to be signed."
   [server-url edn-ize key-fn headers-fn input-map-or-file ch]
   (let [xhr (XhrIo.)


### PR DESCRIPTION
[Related issue](https://github.com/martinklepsch/s3-beam/issues/23). Here is an example usage of the new feature. It allows for dynamically created headers and URL parameters.This change does not break the external API. 

```clojure
(defn jwt-headers
  []
  {"Authorization" (str "Token " (u/get-jwt))})

(s3b/s3-pipe uploaded {:server-url "/sign"
                       :headers    (fn [] (http/jwt-headers))
                       :params     (fn [file] {:file-path (.-fullPath file)})})
```