### PR TITLE
Allow the user to upload to S3 through a custom URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ If you want to use a route different than `/sign`, define it in the
 handler, `(GET "/my-cool-route" ...)`, and then pass it in the options
 map to `s3-pipe` in the frontend.
 
+If you are serving your S3 bucket with CloudFront, or another CDN/proxy, you can pass
+`upload-url` as a fifth parameter to `s3-sign`, so that the ClojureScript client is directed
+to upload through this bucket. You still need to pass the bucket name, as the policy that is
+created and signed is based on the bucket name.
+
 ### 3. Integrate the upload pipeline into your frontend
 
 In your frontend code you can now use `s3-beam.client/s3-pipe`.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.martinklepsch/s3-beam "0.5.0"
+(defproject org.martinklepsch/s3-beam "0.5.2-SNAPSHOT"
   :author "Martin Klepsch <http://www.martinklepsch.org>"
   :description "CORS Upload to S3 via Clojure(script)"
   :url "http://github.com/martinklepsch/s3-beam"


### PR DESCRIPTION
If the user doesn't want to expose the bucket name to the end user, or otherwise wants them to upload through another domain name, they can pass site-url as another parameter. The cljs client will be directed to upload to that site-url.