### PR TITLE
support bucket names with a '.'

### DIFF
--- a/src/clj/s3_beam/handler.clj
+++ b/src/clj/s3_beam/handler.clj
@@ -53,7 +53,7 @@
   (assert acl "ACL cannot be nil")
   (assert mime-type "Mime-type cannot be nil.")
   (let [p (policy bucket file-name mime-type 60 acl)]
-    {:action (str "https://" bucket "." (zone->endpoint aws-zone) ".amazonaws.com/")
+    {:action (str "https://" (zone->endpoint aws-zone) ".amazonaws.com/" bucket "/")
      :key    file-name
      :Content-Type mime-type
      :policy p


### PR DESCRIPTION
resolves the issue mentioned

http://stackoverflow.com/a/25336351 , 

allowing uploads to buckets with names containing a '.'