### PR TITLE
Update README to use aws zone name

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please follow Amazon's [official documentation](http://docs.aws.amazon.com/Amazo
             [compojure.route :refer [resources]]))
 
 (def bucket "your-bucket")
-(def aws-zone "s3-eu-west-1")
+(def aws-zone "eu-west-1")
 (def access-key "your-aws-access-key")
 (def secret-key "your-aws-secret-key")
 


### PR DESCRIPTION
Hi,
I have updated the README to use the zone name, instead of the S3 endpoints, feel free to merge if it's useful.
Thanks for the library!