### PR TITLE
Fix shadow-cljs build failure

### DIFF
--- a/src/cljs/s3_beam/client.cljs
+++ b/src/cljs/s3_beam/client.cljs
@@ -6,8 +6,7 @@
             [goog.events :as events]
             [goog.Uri.QueryData :as qd])
   (:import [goog Uri]
-           [goog.net XhrIo EventType ErrorCode]
-           [goog.events EventType]))
+           [goog.net XhrIo EventType ErrorCode]))
 
 (defn file->map [f]
   {:name (.-name f)


### PR DESCRIPTION
Without this change, any dependent project using shadow-cljs as the build tool fails with:

```
[:browser-test] Build failure:
------ ERROR -------------------------------------------------------------------
 File: jar:file:/home/isaac/.m2/repository/org/martinklepsch/s3-beam/0.6.0-alpha2/s3-beam-0.6.0-alpha2.jar!/s3_beam/client.cljs:1:1
--------------------------------------------------------------------------------

   1 | (ns s3-beam.client
-------^------------------------------------------------------------------------
Error in phase :compilation
conflict on "EventType" by "goog.events.EventType" used by "goog.net.EventType"
{:tag :shadow.build.ns-form/require-conflict, :ns-info {:rename-macros nil, :renames {}, :meta {:file "s3_beam/client.cljs", :line 1, :column 5, :end-line 1, :end-column 19}, :use-macros {go cljs.core.async.macros}, :excludes #{}, :name s3-beam.client, :imports {Uri goog.Uri, XhrIo goog.net.XhrIo, EventType goog.net.EventType, ErrorCode goog.net.ErrorCode}, :requires {goog.dom goog.dom, Uri goog.Uri, goog.net.XhrIo goog.net.XhrIo, ErrorCode goog.net.ErrorCode, EventType goog.net.EventType, async cljs.core.async, goog.Uri.QueryData goog.Uri.QueryData, qd goog.Uri.QueryData, goog.Uri goog.Uri, cljs.core.async cljs.core.async, goog.net.EventType goog.net.EventType, goog.events.EventType goog.events.EventType, events goog.events, gdom goog.dom, XhrIo goog.net.XhrIo, cljs.reader cljs.reader, goog.events goog.events, reader cljs.reader, goog.net.ErrorCode goog.net.ErrorCode}, :seen #{:require :require-macros}, :uses {chan cljs.core.async, put! cljs.core.async, close! cljs.core.async, pipeline-async cljs.core.async}, :require-macros {cljs.core.async.macros cljs.core.async.macros}, :flags {:require-macros #{}, :require #{}}, :js-deps {}, :deps [cljs.reader cljs.core.async goog.dom goog.events goog.Uri.QueryData goog.Uri goog.net.XhrIo goog.net.EventType goog.net.ErrorCode goog.events.EventType]}, :merge-key :imports, :sym EventType, :ns goog.events.EventType}
ExceptionInfo: conflict on "EventType" by "goog.events.EventType" used by "goog.net.EventType"
```