### PR TITLE
Send cookies to the signing endpoint.

### DIFF
--- a/src/cljs/s3_beam/client.cljs
+++ b/src/cljs/s3_beam/client.cljs
@@ -71,6 +71,7 @@
                                                        error-message)
                                  :http-error-code http-error-code})
                        (close! ch))))
+    (. xhr setWithCredentials true) ;; send cookies with the request in case the server sign function uses cookie-based authentication
     (. xhr send url "GET" nil (clj->js (if (some? headers-fn)
                                          (headers-fn fmap)
                                          {})))))


### PR DESCRIPTION
A web app I am working on requires users to be authenticated before it will sign uploads to s3.
The upload-signing endpoint uses cookie-based authentication.

Therefore, I propose sending cookies with the GET request to the signing endpoint.

I considered making it a configurable option to send cookies or not, but decided to have it always send cookies since users of this library control the server endpoint and will probably have their app SSL-secured in production.

Thanks,
    Aaron